### PR TITLE
Correct the version of @types/react

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@types/enzyme": "^2.7.2",
     "@types/jest": "^18.1.1",
     "@types/node": "^7.0.5",
-    "@types/react": "5.0.14",
+    "@types/react": "15.0.14",
     "@types/react-dom": "^0.14.22",
     "@types/react-redux": "^4.4.36",
     "enzyme": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,9 +29,13 @@
     "@types/react" "*"
     redux "^3.6.0"
 
-"@types/react@*", "@types/react@5.0.14":
+"@types/react@*":
   version "15.0.4"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.4.tgz#97aedbba00448a137331aa8450232124aeb8d426"
+
+"@types/react@15.0.14":
+  version "15.0.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.14.tgz#07a739b20b0d4cf946f52444d3c40a94d4a234b1"
 
 abab@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Which I believe should have been `15.0.14`. I was getting this:

```
$ yarn
yarn install v0.24.4
[1/4] Resolving packages...
warning Lockfile has incorrect entry for "@types/react@5.0.14". Ingoring it.
Couldn't find any versions for "@types/react" that matches "5.0.14"
? Please choose a version of "@types/react" from this list: (Use arrow keys)
> 15.0.24
  15.0.23
  15.0.22
  15.0.21
  15.0.20
  15.0.19
  15.0.18
(Move up and down to reveal more choices)
```