### PR TITLE
Fix wrong @types/react version. Changed to latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@types/enzyme": "^2.7.2",
     "@types/jest": "^18.1.1",
     "@types/node": "^7.0.5",
-    "@types/react": "5.0.14",
+    "@types/react": "15.0.24",
     "@types/react-dom": "^0.14.22",
     "@types/react-redux": "^4.4.36",
     "enzyme": "^2.7.1",


### PR DESCRIPTION
Fixes an incorrect `@types/react` version number (5.0.14), changing it to the latest version (15.0.24).

Using `@types/react@5.0.14` results in the following error when running `npm install`:
```No compatible version found: @types/react@5.0.14```

