### PR TITLE
README import typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Now that we've written our component, let's dive into `index.tsx` and replace ou
 First we'll import it at the top of the file:
 
 ```ts
-import Hello from './components/Hello.tsx';
+import Hello from './components/Hello';
 ```
 
 and then change up our `render` call:


### PR DESCRIPTION
There was a typo on the README when specified to import the Hello.tsx file in the index.tsx file. It is not necessary to put the file extension .tsx when importing making it enough to have './components/Hello'