### PR TITLE
Added class based example & updated README docs with common error resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,23 @@ export function mapDispatchToProps(dispatch: Dispatch<actions.EnthusiasmAction>)
 export default connect(mapStateToProps, mapDispatchToProps)(Hello);
 ```
 
+**Note**: If we're getting a TypeScript compile error: *Argument of type 'typeof Hello' is not assignable to parameter...* try implementing the following change:
+
+```ts
+// From:
+export default connect(mapStateToProps, mapDispatchToProps)(Hello);
+
+// To be:
+export function mergeProps(stateProps: Object, dispatchProps: Object, ownProps: Object) {
+  return Object.assign({}, ownProps, stateProps, dispatchProps);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Hello);
+```
+
+
+This implements the default `mergeProps` [used in react-redux](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options) explicitly. This error may have resulted if we implementing a class based `src/components/Hello.tsx` (e.g. `class Hello extends React.Component<Props, object>`).
+
 ## Creating a store
 
 Let's go back to `src/index.tsx`.

--- a/src/components/Hello.ClassBased.tsx
+++ b/src/components/Hello.ClassBased.tsx
@@ -1,0 +1,41 @@
+/*
+ Bellow is an example of a final class based the Hello React.Component
+ To use rename to Hello.tsx, replacing the function based Hello.tsx file
+ */
+import * as React from 'react';
+import './Hello.css';
+
+export interface Props {
+    name: string;
+    enthusiasmLevel?: number;
+    onIncrement?: () => void;
+    onDecrement?: () => void;
+}
+
+class Hello extends React.Component<Props, object> {
+    getExclamationMarks(numChars: number) {
+        return Array(numChars + 1).join('!');
+    }
+
+    render() {
+        const { name, enthusiasmLevel = 1, onIncrement, onDecrement } = this.props;
+
+        if (enthusiasmLevel <= 0) {
+            throw new Error('You could be a little more enthusiastic. :D');
+        }
+
+        return (
+            <div className="hello">
+                <div className="greeting">
+                    Hello {name + this.getExclamationMarks(enthusiasmLevel)}
+                </div>
+                <div>
+                    <button onClick={onDecrement}>-</button>
+                    <button onClick={onIncrement}>+</button>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default Hello;

--- a/src/components/Hello.tsx
+++ b/src/components/Hello.tsx
@@ -1,3 +1,6 @@
+/*
+ Function based Hello.tsx see Hello.ClassBased.tsx for a Class based
+ */
 import * as React from 'react';
 import './Hello.css';
 


### PR DESCRIPTION
# Goals

- [x] Wanted class based example #29 
- [x] Notate how to get around the seemly common: (see #29 #34 #36 #37)

    > /src/containers/Hello.tsx (20,61): error TS2345: Argument of type 'typeof Hello' is not assignable to parameter of type 'Component<{ enthusiasmLevel: number; name: string; } & { onIncrement: () => IncrementEnthusiasm; .. .'. Type 'typeof Hello' is not assignable to type 'StatelessComponent<{ enthusiasmLevel: number; na me: string; } & { onIncrement: () => IncrementEnt...'. Type 'typeof Hello' provides no match for the signature '(props: { enthusiasmLevel: number; n ame: string; } & { onIncrement: () => IncrementEnthusiasm; onDecrement: () => DecrementEnthusiasm ; } & { children?: ReactNode; }, context?: any): ReactElement<any>'.

@DanielRosenwasser I noticed in #37 you said you'd look into it. Until a real resolution (updating the `@types/react-redux` I believe?) is present, I wanted to provide these changes in the meantime after my experience and resolution in #29.
