### PR TITLE
Remove "typePatches" from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,5 @@
     "webpack",
     "jest",
     "src/setupTests.ts"
-  ],
-  "types": [
-    "typePatches"
   ]
 }


### PR DESCRIPTION
See this issue: https://github.com/Microsoft/TypeScript-React-Starter/issues/41

According to wmonk, "typePatches" is not needed: https://github.com/wmonk/create-react-app-typescript/issues/89