### PR TITLE
Added missing semicolon

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ This `const`/`type` pattern allows us to use TypeScript's string literal types i
 Next, we'll create a set of actions and functions that can create these actions in `src/actions/index.tsx`.
 
 ```ts
-import * as constants from '../constants'
+import * as constants from '../constants';
 
 export interface IncrementEnthusiasm {
     type: constants.INCREMENT_ENTHUSIASM;


### PR DESCRIPTION
A missing semicolon is not a syntax error, but it was inconsistent with the rest of the document.