### PR TITLE
Fixed faulty member-ordering ruleset.

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -25,9 +25,13 @@
         "max-line-length": [ true, 120 ],
         "member-ordering": [
             true,
-            "public-before-private",
-            "static-before-instance",
-            "variables-before-functions"
+            {
+                "order": [
+                    "public-before-private",
+                    "static-before-instance",
+                    "variables-before-functions"
+                ]
+            }
         ],
         "no-any": true,
         "no-arg": true,


### PR DESCRIPTION
member-ordering need to contain boolean with a following object with an array containing the order.

See:
https://palantir.github.io/tslint/rules/member-ordering/