### PR TITLE
Add instructions for existing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ We'll create a new project called `my-app`:
 create-react-app my-app --scripts-version=react-scripts-ts
 ```
 
+(If you have an existing server project from which you want to serve the React content, just run the command above from your existing project root, e.g. with project name 'client'.  The React bundle can then be [served statically from the 'client' directory](https://www.fullstackreact.com/articles/using-create-react-app-with-a-server/).)
+
 [react-scripts-ts](https://www.npmjs.com/package/react-scripts-ts) is a set of adjustments to take the standard create-react-app project pipeline and bring TypeScript into the mix.
 
 At this point, your project layout should look like the following:


### PR DESCRIPTION
Finding out this information wasted 2-3 hours of dev time for me today.  We need to serve the files from a custom Hapi server, and it's not obvious that this project can actually be created as a subproject of an existing server.

I think this info will help a lot of people!  Thanks for your consideration.