### PR TITLE
Change the tslint defaultSeverity to warning

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -95,5 +95,6 @@
             "check-type",
             "check-typecast"
         ]
-    }
+    },
+    "defaultSeverity": "warning"
 }


### PR DESCRIPTION
Feedback shows that users are confused that in the sample tslint errors show up as errors https://github.com/Microsoft/vscode-tslint/issues/284. 

This PR changes the default severity of tslint to warnings.