### PR TITLE
Fix README instruction on installing enzyme

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,11 +254,11 @@ Enzyme is similar, but builds on jsdom and makes it easier to make certain queri
 Let's install it as a development-time dependency.
 
 ```sh
-npm install -D enzyme @types/enzyme react-addons-test-utils
+npm install -D enzyme enzyme-adapter-react-16 @types/enzyme @types/enzyme-adapter-react-16 react-addons-test-utils
 ```
 
-Notice we installed packages `enzyme` as well as `@types/enzyme`.
-The `enzyme` package refers to the package containing JavaScript code that actually gets run, while `@types/enzyme` is a package that contains declaration files (`.d.ts` files) so that TypeScript can understand how you can use Enzyme.
+Notice we installed packages `enzyme` and `enzyme-adapter-react-16`, as well as `@types/enzyme` and `@types/enzyme-adapter-react-16`.
+The `enzyme` and `enzyme-adapter-react-16` packages refer to the packages containing JavaScript code that actually gets run, while `@types/enzyme` and `@types/enzyme-adapter-react-16` are packages that contain declaration files (`.d.ts` files) so that TypeScript can understand how you can use Enzyme.
 You can learn more about `@types` packages [here](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html).
 
 We also had to install `react-addons-test-utils`.
@@ -272,7 +272,10 @@ Let's create a file named `src/components/Hello.test.tsx`, adjacent to our `Hell
 
 import * as React from 'react';
 import * as enzyme from 'enzyme';
+import * as Adapter from 'enzyme-adapter-react-16';
 import Hello from './Hello';
+
+enzyme.configure({ adapter: new Adapter() });
 
 it('renders the correct text when no enthusiasm level is given', () => {
   const hello = enzyme.shallow(<Hello name='Daniel' />);


### PR DESCRIPTION
According to the Enzyme docs, the installation procedure should include the enzyme-adapter-react-16 package as well. Its declaration file is need too, because TS.
Tests will fail for people following the step-by-step instructions unless these packages are added. This could close #69 and #76.
Also changing the test template to load the adapter.