### PR TITLE
In the switch statement, have a default case.

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,8 +440,9 @@ export function enthusiasm(state: StoreState, action: EnthusiasmAction): StoreSt
       return { ...state, enthusiasmLevel: state.enthusiasmLevel + 1 };
     case DECREMENT_ENTHUSIASM:
       return { ...state, enthusiasmLevel: Math.max(1, state.enthusiasmLevel - 1) };
+    default:
+      return state;
   }
-  return state;
 }
 ```
 


### PR DESCRIPTION
TSLint didn't like the fact that a default case is missing from the `reducers/index.tsx` file in the README.md. 

Instead of returning the state outside of the switch statement, it is best to return it in the default case.