### PR TITLE
fix npm run test error

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "react-scripts-ts start",
     "build": "react-scripts-ts build",
-    "test": "react-scripts-ts test --env=jsdom",
+    "test": "react-scripts-ts test --env=jsdom --watchAll",
     "eject": "react-scripts-ts eject"
   }
 }


### PR DESCRIPTION
```

--watch is not supported without git/hg, please use --watchAll
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! my-app@0.1.0 test: `react-scripts-ts test --env=jsdom`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the my-app@0.1.0 test script 'react-scripts-ts test --env=jsdom'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the my-app package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     react-scripts-ts test --env=jsdom
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs my-app
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls my-app
npm ERR! There is likely additional logging output above.

```