### PR TITLE
Removed default to 1 for currentEnthusiasm property in constructor in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ interface State {
 class Hello extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { currentEnthusiasm: props.enthusiasmLevel || 1 };
+    this.state = { currentEnthusiasm: props.enthusiasmLevel === undefined ? 1 : props.enthusiasmLevel };
   }
 
   onIncrement = () => this.updateEnthusiasm(this.state.currentEnthusiasm + 1);


### PR DESCRIPTION
… readme for statful components otherwise tests fails

Following your readme noticed that after adding tests they are failing because of `||`. Not sure if that was intentional or not. Added comparison for undefined. Maybe there should be a test for `null` as well :)