### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,8 @@ Let's create a file named `src/containers/Hello.tsx` and start off with the foll
 import Hello from '../components/Hello';
 import * as actions from '../actions/';
 import { StoreState } from '../types/index';
-import { connect, Dispatch } from 'react-redux';
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
 ```
 
 The real two key pieces here are the original `Hello` component as well as the `connect` function from react-redux.
@@ -690,7 +691,8 @@ When we're finished, our file should look like this:
 import Hello from '../components/Hello';
 import * as actions from '../actions/';
 import { StoreState } from '../types/index';
-import { connect, Dispatch } from 'react-redux';
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
 
 export function mapStateToProps({ enthusiasmLevel, languageName }: StoreState) {
   return {


### PR DESCRIPTION
`Dispatch` is no longer exported from `react-redux` but rather, `redux`:

https://github.com/Microsoft/TypeScript-React-Starter/issues/160