### PR TITLE
Fix tests in README to correctly use enzyme dive

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,29 +407,29 @@ import * as enzyme from 'enzyme';
 import Hello from './Hello';
 
 it('renders the correct text when no enthusiasm level is given', () => {
-  const hello = enzyme.shallow(<Hello name='Daniel' />);
+  const hello = enzyme.shallow(<Hello name='Daniel' />).dive();
   expect(hello.find(".greeting").text()).toEqual('Hello Daniel!')
 });
 
 it('renders the correct text with an explicit enthusiasm of 1', () => {
-  const hello = enzyme.shallow(<Hello name='Daniel' enthusiasmLevel={1}/>);
+  const hello = enzyme.shallow(<Hello name='Daniel' enthusiasmLevel={1}/>).dive();
   expect(hello.find(".greeting").text()).toEqual('Hello Daniel!')
 });
 
 it('renders the correct text with an explicit enthusiasm level of 5', () => {
-  const hello = enzyme.shallow(<Hello name='Daniel' enthusiasmLevel={5} />);
+  const hello = enzyme.shallow(<Hello name='Daniel' enthusiasmLevel={5} />).dive();
   expect(hello.find(".greeting").text()).toEqual('Hello Daniel!!!!!');
 });
 
 it('throws when the enthusiasm level is 0', () => {
   expect(() => {
-    enzyme.shallow(<Hello name='Daniel' enthusiasmLevel={0} />);
+    enzyme.shallow(<Hello name='Daniel' enthusiasmLevel={0} />).dive();
   }).toThrow();
 });
 
 it('throws when the enthusiasm level is negative', () => {
   expect(() => {
-    enzyme.shallow(<Hello name='Daniel' enthusiasmLevel={-1} />);
+    enzyme.shallow(<Hello name='Daniel' enthusiasmLevel={-1} />).dive();
   }).toThrow();
 });
 ```


### PR DESCRIPTION
When following the instructions in the readme i wasn't able to get the tests working. After some playing around it seems .dive is required when shallow rendering components with Enzyme. Otherwise render is never called on the component.

I don't have much React/Enzyme knowledge so i'm not sure if this is just on my end. But I don't think that is the case here.