### PR TITLE
Correct "Cannot find name 'AsyncIterator' " error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "build/dist",
     "module": "commonjs",
     "target": "es5",
-    "lib": ["es6", "dom"],
+    "lib": ["es6", "dom", "esnext.asynciterable"],
     "sourceMap": true,
     "allowJs": true,
     "jsx": "react",


### PR DESCRIPTION
Related to issue #142, correct solution is provided but has not been incorporates to the repo yet