### PR TITLE
Ignore yarn.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+yarn.lock
 
 # testing
 /coverage


### PR DESCRIPTION
This should rarely be tracked by git, and as this file is used in the template, we should have it default to untracked.