### PR TITLE
Fixed an issue in the sample code where if the prop enthusiasmLevel w…

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ interface State {
 class Hello extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { currentEnthusiasm: props.enthusiasmLevel || 1 };
+    this.state = { currentEnthusiasm: props.enthusiasmLevel };
   }
 
   onIncrement = () => this.updateEnthusiasm(this.state.currentEnthusiasm + 1);
@@ -308,6 +308,10 @@ class Hello extends React.Component<Props, State> {
     this.setState({ currentEnthusiasm });
   }
 }
+
+Hello.defaultProps = {
+  enthusiasmLevel: 1,
+};
 
 export default Hello;
 


### PR DESCRIPTION
fixes #185 There was an issue in the sample code where if the prop enthusiasmLevel was passed as 0 the error 'You could be a little more enthusiastic. :D' would never be thrown. Used reacts defaultProps to pass enthusiasmLevel's default value as 1. This should allow 0 to still be passed resolving the issue.