### PR TITLE
Force off TSLint check for interface naming.

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,9 @@
 {
     "extends": [],
     "defaultSeverity": "warning",
+    "rules": {
+        "interface-name": false
+    },
     "linterOptions": {
       "exclude": [
         "config/**/*.js",


### PR DESCRIPTION
This will address #171 in lieu of the README changes made in #172 