### PR TITLE
Fix state initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ interface State {
 class Hello extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { currentEnthusiasm: props.enthusiasmLevel || 1 };
+    this.state = { currentEnthusiasm: typeof props.enthusiasmLevel !== 'undefined' ? props.enthusiasmLevel : 1 };
   }
 
   onIncrement = () => this.updateEnthusiasm(this.state.currentEnthusiasm + 1);


### PR DESCRIPTION
Without this PR, when `props.enthusiasmLevel` is set to 0, the expression `props.enthusiasmLevel || 1` always equals to 1. Therefore the render doesn't throw as expected and one of the tests fails.