### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,12 +408,12 @@ import Hello from './Hello';
 
 it('renders the correct text when no enthusiasm level is given', () => {
   const hello = enzyme.shallow(<Hello name='Daniel' />);
-  expect(hello.find(".greeting").text()).toEqual('Hello Daniel!')
+  expect(hello.find(".greeting").text()).toEqual('Hello Daniel!');
 });
 
 it('renders the correct text with an explicit enthusiasm of 1', () => {
   const hello = enzyme.shallow(<Hello name='Daniel' enthusiasmLevel={1}/>);
-  expect(hello.find(".greeting").text()).toEqual('Hello Daniel!')
+  expect(hello.find(".greeting").text()).toEqual('Hello Daniel!');
 });
 
 it('renders the correct text with an explicit enthusiasm level of 5', () => {
@@ -656,7 +656,7 @@ export function mapStateToProps({ enthusiasmLevel, languageName }: StoreState) {
   return {
     enthusiasmLevel,
     name: languageName,
-  }
+  };
 }
 ```
 
@@ -670,7 +670,7 @@ export function mapDispatchToProps(dispatch: Dispatch<actions.EnthusiasmAction>)
   return {
     onIncrement: () => dispatch(actions.incrementEnthusiasm()),
     onDecrement: () => dispatch(actions.decrementEnthusiasm()),
-  }
+  };
 }
 ```
 
@@ -696,14 +696,14 @@ export function mapStateToProps({ enthusiasmLevel, languageName }: StoreState) {
   return {
     enthusiasmLevel,
     name: languageName,
-  }
+  };
 }
 
 export function mapDispatchToProps(dispatch: Dispatch<actions.EnthusiasmAction>) {
   return {
     onIncrement: () => dispatch(actions.incrementEnthusiasm()),
     onDecrement: () => dispatch(actions.decrementEnthusiasm()),
-  }
+  };
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Hello);

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For it to run correctly, we'll need to initialize a git repository.
 ```sh
 git init
 git add .
-git commit -m "Initial commit."
+git commit -m "Initial commit"
 ```
 
 > Note: if you've cloned this repository, you won't have to run the above at all.


### PR DESCRIPTION
This PR does two things:

1. Add semicolons to README.md in order to match original code (similarly to #177)
2. Remove the "." after the "Initial commit" to match [common](https://chris.beams.io/posts/git-commit/#end) [style](https://github.com/erlang/otp/wiki/writing-good-commit-messages#dont) [guides](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53#rules-for-a-great-git-commit-message-style) for commit messages and this own projects initial commit messages