### PR TITLE
StatefulHello passes npm run test

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ interface State {
 class Hello extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { currentEnthusiasm: props.enthusiasmLevel || 1 };
+    this.state = { currentEnthusiasm: props.enthusiasmLevel == null ? 1 : props.enthusiasmLevel };
   }
 
   onIncrement = () => this.updateEnthusiasm(this.state.currentEnthusiasm + 1);


### PR DESCRIPTION
Although we don't run tests on `StatefulHello` on the tutorial, it is intended by the authors to pass the same tests as the `Hello` component. Thus we need to stop converting `enthusiasmLevel` to `1` when`0` is passed in.