### PR TITLE
Update stateful component example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ interface State {
 class Hello extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { currentEnthusiasm: props.enthusiasmLevel || 1 };
+    this.state = { currentEnthusiasm: props.enthusiasmLevel === undefined ? 1 : props.enthusiasmLevel };
   }
 
   onIncrement = () => this.updateEnthusiasm(this.state.currentEnthusiasm + 1);


### PR DESCRIPTION
`this.state = { currentEnthusiasm: props.enthusiasmLevel || 1 };` doesn't fill its intended purpose when the prop is falsy, such as `0`.

The original form actually fails the enzymes tests defined in the next section.