### PR TITLE
Add react-scripts-ts to development-time dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ These tests are extremely basic, but you should be able to get the gist of thing
 
 Notice:
 
-If you find yourself getting an error when trying to run ```sh npm run test``` after installing enzyme make sure react-script-ts is installed in your package.json file under "devDependencies". If not, this can be installed as a development-time dependency using the follow command:
+If you find yourself getting an error when trying to run ```npm run test``` after installing enzyme make sure react-script-ts is installed in your package.json file under "devDependencies". If not, this can be installed as a development-time dependency using the follow command:
 
 ```sh
 npm install react-scripts-ts@4.0.8 

--- a/README.md
+++ b/README.md
@@ -436,6 +436,14 @@ it('throws when the enthusiasm level is negative', () => {
 
 These tests are extremely basic, but you should be able to get the gist of things.
 
+Notice:
+
+If you find yourself getting an error when trying to run ```sh npm run test``` after installing enzyme make sure react-script-ts is installed in your package.json file under "devDependencies". If not, this can be installed as a development-time dependency using the follow command:
+
+```sh
+npm install react-scripts-ts@4.0.8 
+```
+
 # Adding state management
 
 At this point, if all you're using React for is fetching data once and displaying it, you can consider yourself done.

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Notice:
 If you find yourself getting an error when trying to run ```npm run test``` after installing enzyme make sure react-script-ts is installed in your package.json file under "devDependencies". If not, this can be installed as a development-time dependency using the follow command:
 
 ```sh
-npm install react-scripts-ts@4.0.8 
+npm install -D react-scripts-ts@4.0.8 
 ```
 
 # Adding state management


### PR DESCRIPTION
I was having an issue running npm run tests after install enzyme.

After updating the development-time dependencies with react-script-ts I was able to run "npm run tests" again and have all 6 tests pass!