### PR TITLE
Fixed Hello constructor this.state.currentEnthusiasm assigment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,18 @@ interface State {
 class Hello extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { currentEnthusiasm: props.enthusiasmLevel || 1 };
+    /*
+     * If enthusiam is set to 0 without the if clause
+     * the || will review it as falsy and adjust it to 1.
+     * This behavior will clash with the Hello.test.tsx test:
+     * 'throws when the enthusiasm level is 0' since it will
+     * not throw but result in 1 exclamation mark after the name.
+     */
+    if(props.enthusiasmLevel !== 0){
+      this.state = { currentEnthusiasm: props.enthusiasmLevel || 1 };
+    } else {
+      this.state = {currentEnthusiasm: 0}
+    }
   }
 
   onIncrement = () => this.updateEnthusiasm(this.state.currentEnthusiasm + 1);


### PR DESCRIPTION
There's was an overlooked behavior inconsistency between the assignment of `this.state.currentEnthusiasm` assigment  at the Hello component constructor and the expect behavior in the test 'throws when the enthusiasm level is 0'.

I fixed the assignment rather than the test itself so that the wanted behavior will work. When `enthusiamLevel` is 0 it will now actually throw and error instead of bypassing the `falsy` value and setting `this.state.currentEnthusiasm` to 1.