### PR TITLE
fix: README.md test/enzyme setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,8 +390,8 @@ Before writing the first test, we have to configure Enzyme to use an adapter for
 We'll create a file called `src/setupTests.ts` that is automatically loaded when running tests:
 
 ```ts
-import * as enzyme from 'enzyme';
-import * as Adapter from 'enzyme-adapter-react-16';
+import enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 enzyme.configure({ adapter: new Adapter() });
 ```


### PR DESCRIPTION
fixes error in read me where the setup for enzyme and enzyme-adapter-react-16
are thowing error: TypeError: Adapter is not a constructor. This is due
to Adapter is default exported and therefor should not be imported as
star.

research:
https://stackoverflow.com/questions/49824423/enzyme-typeerror-adapter-is-not-a-constructor