### PR TITLE
update react-redux Dispatch type

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ Let's create a file named `src/containers/Hello.tsx` and start off with the foll
 import Hello from '../components/Hello';
 import * as actions from '../actions/';
 import { StoreState } from '../types/index';
-import { connect, Dispatch } from 'react-redux';
+import { connect, DispatchProp } from 'react-redux';
 ```
 
 The real two key pieces here are the original `Hello` component as well as the `connect` function from react-redux.
@@ -666,7 +666,7 @@ Namely, we still want to pass in the `onIncrement` and `onDecrement` callbacks.
 This dispatcher function can pass actions into our store to make updates, so we can create a pair of callbacks that will call the dispatcher as necessary.
 
 ```ts
-export function mapDispatchToProps(dispatch: Dispatch<actions.EnthusiasmAction>) {
+export function mapDispatchToProps(dispatch: DispatchProp<actions.EnthusiasmAction>) {
   return {
     onIncrement: () => dispatch(actions.incrementEnthusiasm()),
     onDecrement: () => dispatch(actions.decrementEnthusiasm()),


### PR DESCRIPTION
Looks like we should use [DispatchProp](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0341d2d0824c45ff6a7a49b0c83a13f17d966f7c/types/react-redux/index.d.ts#L51) in sample code to avoid type check error.